### PR TITLE
Implement basic Qt terminal GUI

### DIFF
--- a/MakeTermianlMain/MakeTermianlMain.pro
+++ b/MakeTermianlMain/MakeTermianlMain.pro
@@ -1,13 +1,17 @@
-QT = core
+QT += core gui widgets
 
-CONFIG += c++17 cmdline
+CONFIG += c++17
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
+HEADERS += \
+    TerminalWindow.h
+
 SOURCES += \
-        main.cpp
+    main.cpp \
+    TerminalWindow.cpp
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/MakeTermianlMain/TerminalWindow.cpp
+++ b/MakeTermianlMain/TerminalWindow.cpp
@@ -1,0 +1,50 @@
+#include "TerminalWindow.h"
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QProcess>
+#include <QVBoxLayout>
+#include <QWidget>
+
+TerminalWindow::TerminalWindow(QWidget *parent)
+    : QMainWindow(parent),
+      m_outputArea(new QPlainTextEdit(this)),
+      m_inputLine(new QLineEdit(this)),
+      m_process(new QProcess(this))
+{
+    QWidget *central = new QWidget(this);
+    setCentralWidget(central);
+
+    m_outputArea->setReadOnly(true);
+
+    QVBoxLayout *layout = new QVBoxLayout(central);
+    layout->addWidget(m_outputArea);
+    layout->addWidget(m_inputLine);
+
+    connect(m_inputLine, &QLineEdit::returnPressed,
+            this, &TerminalWindow::executeCommand);
+    connect(m_process, &QProcess::readyReadStandardOutput,
+            this, &TerminalWindow::readProcessOutput);
+    connect(m_process, &QProcess::readyReadStandardError,
+            this, &TerminalWindow::readProcessError);
+}
+
+void TerminalWindow::executeCommand()
+{
+    QString cmd = m_inputLine->text();
+    if (cmd.isEmpty())
+        return;
+
+    m_outputArea->appendPlainText("$ " + cmd);
+    m_process->start("/bin/sh", {"-c", cmd});
+    m_inputLine->clear();
+}
+
+void TerminalWindow::readProcessOutput()
+{
+    m_outputArea->appendPlainText(QString::fromLocal8Bit(m_process->readAllStandardOutput()));
+}
+
+void TerminalWindow::readProcessError()
+{
+    m_outputArea->appendPlainText(QString::fromLocal8Bit(m_process->readAllStandardError()));
+}

--- a/MakeTermianlMain/TerminalWindow.h
+++ b/MakeTermianlMain/TerminalWindow.h
@@ -1,0 +1,27 @@
+#ifndef TERMINALWINDOW_H
+#define TERMINALWINDOW_H
+
+#include <QMainWindow>
+
+class QLineEdit;
+class QPlainTextEdit;
+class QProcess;
+
+class TerminalWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit TerminalWindow(QWidget *parent = nullptr);
+
+private slots:
+    void executeCommand();
+    void readProcessOutput();
+    void readProcessError();
+
+private:
+    QPlainTextEdit *m_outputArea;
+    QLineEdit *m_inputLine;
+    QProcess *m_process;
+};
+
+#endif // TERMINALWINDOW_H

--- a/MakeTermianlMain/main.cpp
+++ b/MakeTermianlMain/main.cpp
@@ -1,8 +1,10 @@
-#include <QCoreApplication>
+#include <QApplication>
+#include "TerminalWindow.h"
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication a(argc, argv);
-
+    QApplication a(argc, argv);
+    TerminalWindow w;
+    w.show();
     return a.exec();
 }


### PR DESCRIPTION
## Summary
- convert console app into Qt Widgets app
- add `TerminalWindow` class that runs shell commands
- show `TerminalWindow` from `main.cpp`

## Testing
- `qmake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5fc80890832a9847e53c192e278d